### PR TITLE
separate evaluate and upload test data

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -25,4 +25,5 @@ $ sh drucker-grpc-proto/run_codegen.sh
 $ cp drucker-grpc-proto/protobuf/drucker_pb2.py .
 $ cp drucker-grpc-proto/protobuf/drucker_pb2_grpc.py .
 $ python -m unittest test/test_api_service.py
+$ python -m unittest test/test_api_application.py
 ```

--- a/app/apis/api_application.py
+++ b/app/apis/api_application.py
@@ -133,7 +133,7 @@ class ApiEvaluation(Resource):
         """update data to be evaluated"""
         args = self.upload_parser.parse_args()
         file = args['file']
-        eval_data_path = "eval-{0:%Y%m%d%H%M%S}".format(datetime.datetime.utcnow())
+        eval_data_path = "eval-{0:%Y%m%d%H%M%S}.txt".format(datetime.datetime.utcnow())
 
         sobj = Service.query.filter_by(application_id=application_id).first_or_404()
 

--- a/app/apis/api_application.py
+++ b/app/apis/api_application.py
@@ -140,13 +140,17 @@ class ApiEvaluation(Resource):
         drucker_dashboard_application = DruckerDashboardClient(logger=logger, host=sobj.host)
         response_body = drucker_dashboard_application.run_upload_evaluation_data(file, eval_data_path)
 
-        if response_body['status']:
-            eobj = Evaluation(application_id=application_id, data_path=eval_data_path)
-            db.session.add(eobj)
-            db.session.commit()
-            db.session.close()
+        if not response_body['status']:
+            raise Exception('Failed to upload')
+        eobj = Evaluation(application_id=application_id, data_path=eval_data_path)
+        db.session.add(eobj)
+        db.session.flush()
+        evaluation_id = eobj.evaluation_id
+        db.session.commit()
+        db.session.close()
 
-        return response_body
+        return {"status": True, "evaluation_id": evaluation_id}
+
 
 @app_info_namespace.route('/<int:application_id>/evaluation/<int:evaluation_id>')
 class ApiEvaluation(Resource):

--- a/app/apis/api_application.py
+++ b/app/apis/api_application.py
@@ -165,7 +165,6 @@ class ApiEvaluation(Resource):
         eval_query.delete()
         db.session.query(EvaluationResult)\
             .filter(EvaluationResult.evaluation_id == evaluation_id).delete()
-        db.session.flush()
         db.session.commit()
         db.session.close()
 

--- a/app/apis/api_service.py
+++ b/app/apis/api_service.py
@@ -215,7 +215,7 @@ class ApiEvaluate(Resource):
         response_body = drucker_dashboard_application.run_evaluate_model(eobj.data_path, eval_result_path)
 
         if response_body['status']:
-            robj = EvaluationResult(service_id=service_id, data_path=eval_result_path, evaluation_id=eobj.evaluation_id)
+            robj = EvaluationResult(model_id=sobj.model_id, data_path=eval_result_path, evaluation_id=eobj.evaluation_id)
             db.session.add(robj)
             db.session.commit()
             db.session.close()

--- a/app/apis/api_service.py
+++ b/app/apis/api_service.py
@@ -213,8 +213,8 @@ class ApiEvaluate(Resource):
             service_id=service_id).first_or_404()
 
         robj = db.session.query(EvaluationResult)\
-            .filter(EvaluationResult.model_id == sobj.model_id)\
-            .filter(EvaluationResult.evaluation_id == eobj.evaluation_id).one_or_none()
+            .filter(EvaluationResult.model_id == sobj.model_id,
+                    EvaluationResult.evaluation_id == eobj.evaluation_id).one_or_none()
         if robj is not None and args.get('overwrite', False):
             return json.loads(robj.result)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -42,3 +42,4 @@ from models.application import Application
 from models.service import Service
 from models.model import Model
 from models.evaluation import Evaluation
+from models.evaluation_result import EvaluationResult

--- a/app/models/evaluation.py
+++ b/app/models/evaluation.py
@@ -15,10 +15,12 @@ class Evaluation(db.Model):
     __tablename__ = 'evaluations'
     __table_args__ = (
         UniqueConstraint('evaluation_id'),
+        UniqueConstraint('checksum'),
         {'mysql_engine': 'InnoDB'}
     )
 
     evaluation_id = Column(Integer, primary_key=True, autoincrement=True)
+    checksum = Column(String(128), nullable=False)
     application_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
@@ -28,6 +30,7 @@ class Evaluation(db.Model):
     def serialize(self):
         return {
             'evaluation_id': self.evaluation_id,
+            'checksum': self.checksum,
             'application_id': self.application_id,
             'data_path': self.data_path,
             'register_date': self.register_date.strftime('%Y-%m-%d %H:%M:%S'),

--- a/app/models/evaluation.py
+++ b/app/models/evaluation.py
@@ -22,7 +22,7 @@ class Evaluation(db.Model):
     application_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
-    evaluation_result = relationship('EvaluationResult', lazy='select', innerjoin=True)
+    evaluation_result = relationship('EvaluationResult', backref='evaluations', lazy='select', innerjoin=True)
 
     @property
     def serialize(self):

--- a/app/models/evaluation.py
+++ b/app/models/evaluation.py
@@ -3,13 +3,14 @@ from sqlalchemy import (
     Column, Integer, DateTime,
     String, UniqueConstraint
 )
+from sqlalchemy.orm import relationship
 
 from models import db
 
 
 class Evaluation(db.Model):
     """
-    Evaluation Info
+    Data to be evaluated
     """
     __tablename__ = 'evaluations'
     __table_args__ = (
@@ -18,15 +19,16 @@ class Evaluation(db.Model):
     )
 
     evaluation_id = Column(Integer, primary_key=True, autoincrement=True)
-    service_id = Column(Integer, nullable=False)
+    application_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+    evaluation_result = relationship('EvaluationResult', lazy='select', innerjoin=True)
 
     @property
     def serialize(self):
         return {
             'evaluation_id': self.evaluation_id,
-            'service_id': self.service_id,
+            'application_id': self.application_id,
             'data_path': self.data_path,
             'register_date': self.register_date.strftime('%Y-%m-%d %H:%M:%S'),
         }

--- a/app/models/evaluation_result.py
+++ b/app/models/evaluation_result.py
@@ -20,7 +20,7 @@ class EvaluationResult(db.Model):
     evaluation_result_id = Column(Integer, primary_key=True, autoincrement=True)
     service_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
-    evalation_id = Column(Integer, ForeignKey('evaluations.evalation_id', ondelete="cascade"))
+    evaluation_id = Column(Integer, ForeignKey('evaluations.evaluation_id'), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
 
     @property

--- a/app/models/evaluation_result.py
+++ b/app/models/evaluation_result.py
@@ -18,7 +18,7 @@ class EvaluationResult(db.Model):
     )
 
     evaluation_result_id = Column(Integer, primary_key=True, autoincrement=True)
-    service_id = Column(Integer, nullable=False)
+    model_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
     evaluation_id = Column(Integer, ForeignKey('evaluations.evaluation_id'), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
@@ -27,7 +27,7 @@ class EvaluationResult(db.Model):
     def serialize(self):
         return {
             'evaluation_result_id': self.evaluation_result_id,
-            'service_id': self.service_id,
+            'model_id': self.model_id,
             'data_path': self.data_path,
             'evaluation_id': self.evaluation_id,
             'register_date': self.register_date.strftime('%Y-%m-%d %H:%M:%S'),

--- a/app/models/evaluation_result.py
+++ b/app/models/evaluation_result.py
@@ -1,6 +1,6 @@
 import datetime
 from sqlalchemy import (
-    Column, Integer, DateTime,
+    Column, Integer, DateTime, Text,
     UniqueConstraint, ForeignKey, String
 )
 
@@ -21,6 +21,7 @@ class EvaluationResult(db.Model):
     model_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
     evaluation_id = Column(Integer, ForeignKey('evaluations.evaluation_id'), nullable=False)
+    result = Column(Text, nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
 
     @property
@@ -30,5 +31,6 @@ class EvaluationResult(db.Model):
             'model_id': self.model_id,
             'data_path': self.data_path,
             'evaluation_id': self.evaluation_id,
+            'result': self.result,
             'register_date': self.register_date.strftime('%Y-%m-%d %H:%M:%S'),
         }

--- a/app/models/evaluation_result.py
+++ b/app/models/evaluation_result.py
@@ -1,0 +1,34 @@
+import datetime
+from sqlalchemy import (
+    Column, Integer, DateTime,
+    UniqueConstraint, ForeignKey, String
+)
+
+from models import db
+
+
+class EvaluationResult(db.Model):
+    """
+    Evaluation Info
+    """
+    __tablename__ = 'evaluation_results'
+    __table_args__ = (
+        UniqueConstraint('evaluation_result_id'),
+        {'mysql_engine': 'InnoDB'}
+    )
+
+    evaluation_result_id = Column(Integer, primary_key=True, autoincrement=True)
+    service_id = Column(Integer, nullable=False)
+    data_path = Column(String(512), nullable=False)
+    evalation_id = Column(Integer, ForeignKey('evaluations.evalation_id', ondelete="cascade"))
+    register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+
+    @property
+    def serialize(self):
+        return {
+            'evaluation_result_id': self.evaluation_result_id,
+            'service_id': self.service_id,
+            'data_path': self.data_path,
+            'evaluation_id': self.evaluation_id,
+            'register_date': self.register_date.strftime('%Y-%m-%d %H:%M:%S'),
+        }

--- a/app/test/base.py
+++ b/app/test/base.py
@@ -45,6 +45,7 @@ def create_app_obj(kubernetes_id=1, save=False):
 
 def create_service_obj(
         application_id,
+        model_id=3,
         service_name='drucker-test-app-development-20180628151929',
         service_level='development',
         host='localhost:5000',
@@ -53,6 +54,7 @@ def create_service_obj(
                    service_name=service_name,
                    service_level=service_level,
                    host=host,
+                   model_id=model_id,
                    display_name=service_name)
     sobj_ = Service.query.filter_by(
         service_name=service_name).one_or_none()

--- a/app/test/base.py
+++ b/app/test/base.py
@@ -68,9 +68,10 @@ def create_service_obj(
 
 def create_eval_obj(
         application_id,
+        checksum='abcde',
         data_path='my_data_path',
         save=False):
-    eobj = Evaluation(checksum='abcde',
+    eobj = Evaluation(checksum=checksum,
                       application_id=application_id,
                       data_path=data_path)
     if save:

--- a/app/test/base.py
+++ b/app/test/base.py
@@ -3,7 +3,7 @@ import warnings
 from flask import Flask
 from flask_testing import TestCase
 
-from models import db, Application, Service
+from models import db, Application, Service, Evaluation
 from app import initialize_app
 
 
@@ -62,3 +62,15 @@ def create_service_obj(
         return sobj
     else:
         return sobj_
+
+
+def create_eval_obj(
+        application_id,
+        data_path='my_data_path',
+        save=False):
+    eobj = Evaluation(application_id=application_id,
+                      data_path=data_path)
+    if save:
+        db.session.add(eobj)
+        db.session.commit()
+    return eobj

--- a/app/test/base.py
+++ b/app/test/base.py
@@ -3,7 +3,7 @@ import warnings
 from flask import Flask
 from flask_testing import TestCase
 
-from models import db, Application, Service, Evaluation
+from models import db, Application, Service, Evaluation, EvaluationResult
 from app import initialize_app
 
 
@@ -76,3 +76,19 @@ def create_eval_obj(
         db.session.add(eobj)
         db.session.commit()
     return eobj
+
+
+def create_eval_result_obj(
+        model_id,
+        evaluation_id,
+        data_path='my_data_path',
+        result='{}',
+        save=False):
+    robj = EvaluationResult(model_id=model_id,
+                            data_path='my_result_path',
+                            evaluation_id=evaluation_id,
+                            result=result)
+    if save:
+        db.session.add(robj)
+        db.session.commit()
+    return robj

--- a/app/test/base.py
+++ b/app/test/base.py
@@ -70,7 +70,8 @@ def create_eval_obj(
         application_id,
         data_path='my_data_path',
         save=False):
-    eobj = Evaluation(application_id=application_id,
+    eobj = Evaluation(checksum='abcde',
+                      application_id=application_id,
                       data_path=data_path)
     if save:
         db.session.add(eobj)

--- a/app/test/test_api_application.py
+++ b/app/test/test_api_application.py
@@ -17,9 +17,20 @@ class ApiEvaluationTest(BaseTestCase):
         mock_stub_class.return_value = mock_stub_obj
         aobj = create_app_obj()
         create_service_obj(aobj.application_id)
-        response = self.client.post(f'/api/applications/{aobj.application_id}/evaluation',
-                                    content_type='multipart/form-data',
-                                    data=dict(file=(BytesIO(b'my file contents'), "work_order.123")))
+
+        url = f'/api/applications/{aobj.application_id}/evaluation'
+        content_type = 'multipart/form-data'
+        file_content = b'my file contents'
+        response = self.client.post(url,
+                                    content_type=content_type,
+                                    data={'file': (BytesIO(file_content), "file.txt")})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, {'status': True, 'evaluation_id': 1})
+
+        # duplication check
+        response = self.client.post(url,
+                                    content_type=content_type,
+                                    data={'file': (BytesIO(file_content), "file.txt")})
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json, {'status': True, 'evaluation_id': 1})
 

--- a/app/test/test_api_application.py
+++ b/app/test/test_api_application.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch, Mock
+
+import drucker_pb2
+from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj
+from io import BytesIO
+from models import db, EvaluationResult, Evaluation
+
+
+class ApiEvaluationTest(BaseTestCase):
+    """Tests for ApiEvaluation.
+    """
+
+    @patch('core.drucker_dashboard_client.drucker_pb2_grpc.DruckerDashboardStub')
+    def test_post(self, mock_stub_class):
+        mock_stub_obj = Mock()
+        mock_stub_obj.UploadEvaluationData.return_value = drucker_pb2.UploadEvaluationDataResponse(status=1, message='success')
+        mock_stub_class.return_value = mock_stub_obj
+        aobj = create_app_obj()
+        create_service_obj(aobj.application_id)
+        response = self.client.post(f'/api/applications/{aobj.application_id}/evaluation',
+                                    content_type='multipart/form-data',
+                                    data=dict(file=(BytesIO(b'my file contents'), "work_order.123")))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, {'status': 1, 'message': 'success'})
+
+    def test_delete(self):
+        app_id = create_app_obj().application_id
+        eobj = create_eval_obj(app_id, save=True)
+        sobj = create_service_obj(app_id)
+        robj = EvaluationResult(service_id=sobj.service_id,
+                                data_path='my_result_path',
+                                evaluation_id=eobj.evaluation_id)
+        db.session.add(robj)
+        db.session.commit()
+        response = self.client.delete(f'/api/applications/{app_id}/evaluation/{eobj.evaluation_id}')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, {'status': True, 'message': 'Success.'})
+        self.assertEqual(Evaluation.query.all(), [])
+        self.assertEqual(EvaluationResult.query.all(), [])
+
+        response = self.client.delete(f'/api/applications/{app_id}/evaluation/101')
+        self.assertEqual(404, response.status_code)
+        self.assertEqual(response.json, {'status': False})

--- a/app/test/test_api_application.py
+++ b/app/test/test_api_application.py
@@ -27,7 +27,7 @@ class ApiEvaluationTest(BaseTestCase):
         app_id = create_app_obj().application_id
         eobj = create_eval_obj(app_id, save=True)
         sobj = create_service_obj(app_id)
-        robj = EvaluationResult(service_id=sobj.service_id,
+        robj = EvaluationResult(model_id=sobj.model_id,
                                 data_path='my_result_path',
                                 evaluation_id=eobj.evaluation_id)
         db.session.add(robj)

--- a/app/test/test_api_application.py
+++ b/app/test/test_api_application.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch, Mock
 
 import drucker_pb2
-from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj
+from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj, create_eval_result_obj
 from io import BytesIO
-from models import db, EvaluationResult, Evaluation
+from models import EvaluationResult, Evaluation
 
 
 class ApiEvaluationTest(BaseTestCase):
@@ -27,11 +27,7 @@ class ApiEvaluationTest(BaseTestCase):
         app_id = create_app_obj().application_id
         eobj = create_eval_obj(app_id, save=True)
         sobj = create_service_obj(app_id)
-        robj = EvaluationResult(model_id=sobj.model_id,
-                                data_path='my_result_path',
-                                evaluation_id=eobj.evaluation_id)
-        db.session.add(robj)
-        db.session.commit()
+        create_eval_result_obj(model_id=sobj.model_id, evaluation_id=eobj.evaluation_id, save=True)
         response = self.client.delete(f'/api/applications/{app_id}/evaluation/{eobj.evaluation_id}')
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json, {'status': True, 'message': 'Success.'})

--- a/app/test/test_api_application.py
+++ b/app/test/test_api_application.py
@@ -21,7 +21,7 @@ class ApiEvaluationTest(BaseTestCase):
                                     content_type='multipart/form-data',
                                     data=dict(file=(BytesIO(b'my file contents'), "work_order.123")))
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json, {'status': 1, 'message': 'success'})
+        self.assertEqual(response.json, {'status': True, 'evaluation_id': 1})
 
     def test_delete(self):
         app_id = create_app_obj().application_id

--- a/app/test/test_api_service.py
+++ b/app/test/test_api_service.py
@@ -1,19 +1,33 @@
 from unittest.mock import patch, Mock
+from copy import deepcopy
+import json
 
 import drucker_pb2
-from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj
+from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj, create_eval_result_obj
 from models import EvaluationResult, db
+
+
+def patch_stub(func):
+    def inner_method(*args, **kwargs):
+        mock_stub_obj = Mock()
+        mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
+        with patch('core.drucker_dashboard_client.drucker_pb2_grpc.DruckerDashboardStub',
+                   new=Mock(return_value=mock_stub_obj)):
+            return func(*args, **kwargs)
+    return inner_method
 
 
 class ApiEvaluateTest(BaseTestCase):
     """Tests for ApiEvaluate.
     """
+    default_response = {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
+                        'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True}
 
-    @patch('core.drucker_dashboard_client.drucker_pb2_grpc.DruckerDashboardStub')
-    def test_post(self, mock_stub_class):
-        mock_stub_obj = Mock()
-        mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
-        mock_stub_class.return_value = mock_stub_obj
+    def setUp(self):
+        super().setUp()
+
+    @patch_stub
+    def test_post(self):
         aobj = create_app_obj()
         sobj = create_service_obj(aobj.application_id)
         model_id = sobj.model_id
@@ -22,18 +36,14 @@ class ApiEvaluateTest(BaseTestCase):
         response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate',
                                     data={'evaluation_id': evaluation_id})
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
-                                         'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
+        self.assertEqual(response.json, self.default_response)
         eobj_exists = db.session.query(EvaluationResult)\
             .filter(EvaluationResult.model_id == model_id,
                     EvaluationResult.evaluation_id == evaluation_id).one_or_none() is not None
         self.assertEqual(eobj_exists, True)
 
-    @patch('core.drucker_dashboard_client.drucker_pb2_grpc.DruckerDashboardStub')
-    def test_post_without_param(self, mock_stub_class):
-        mock_stub_obj = Mock()
-        mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
-        mock_stub_class.return_value = mock_stub_obj
+    @patch_stub
+    def test_post_without_param(self):
         aobj = create_app_obj()
         sobj = create_service_obj(aobj.application_id)
         model_id = sobj.model_id
@@ -44,9 +54,35 @@ class ApiEvaluateTest(BaseTestCase):
 
         response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate')
         self.assertEqual(200, response.status_code)
-        self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
-                                         'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
+        self.assertEqual(response.json, self.default_response)
         eobj_exists = db.session.query(EvaluationResult)\
             .filter(EvaluationResult.model_id == model_id,
                     EvaluationResult.evaluation_id == newest_eval_id).one_or_none() is not None
         self.assertEqual(eobj_exists, True)
+
+    @patch_stub
+    def test_post_duplicated(self):
+        saved_response = deepcopy(self.default_response)
+        aobj = create_app_obj()
+        sobj = create_service_obj(aobj.application_id)
+        model_id = sobj.model_id
+        evaluation_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
+        create_eval_result_obj(model_id=model_id,
+                               evaluation_id=evaluation_id,
+                               result=json.dumps(saved_response),
+                               save=True)
+
+        url = f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate'
+        response = self.client.post(url, data={'evaluation_id': evaluation_id})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, saved_response)
+
+        # overwrite
+        response = self.client.post(url, data={'evaluation_id': evaluation_id, 'overwrite': True})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, self.default_response)
+
+        eobj = db.session.query(EvaluationResult)\
+            .filter(EvaluationResult.model_id == model_id,
+                    EvaluationResult.evaluation_id == evaluation_id).one()
+        self.assertEqual(json.loads(eobj.result), self.default_response)

--- a/app/test/test_api_service.py
+++ b/app/test/test_api_service.py
@@ -47,9 +47,9 @@ class ApiEvaluateTest(BaseTestCase):
         aobj = create_app_obj()
         sobj = create_service_obj(aobj.application_id)
         model_id = sobj.model_id
-        create_eval_obj(aobj.application_id, save=True)
-        create_eval_obj(aobj.application_id, save=True)
-        create_eval_obj(aobj.application_id, save=True)
+        create_eval_obj(aobj.application_id, checksum='12345', save=True)
+        create_eval_obj(aobj.application_id, checksum='6789', save=True)
+        create_eval_obj(aobj.application_id, checksum='abc', save=True)
         newest_eval_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
 
         response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate')

--- a/app/test/test_api_service.py
+++ b/app/test/test_api_service.py
@@ -15,16 +15,17 @@ class ApiEvaluateTest(BaseTestCase):
         mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
         mock_stub_class.return_value = mock_stub_obj
         aobj = create_app_obj()
-        service_id = create_service_obj(aobj.application_id).service_id
+        sobj = create_service_obj(aobj.application_id)
+        model_id = sobj.model_id
         evaluation_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
 
-        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{service_id}/evaluate',
+        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate',
                                     data={'evaluation_id': evaluation_id})
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
                                          'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
         eobj_exists = db.session.query(EvaluationResult)\
-            .filter(EvaluationResult.service_id == service_id,
+            .filter(EvaluationResult.model_id == model_id,
                     EvaluationResult.evaluation_id == evaluation_id).one_or_none() is not None
         self.assertEqual(eobj_exists, True)
 
@@ -34,17 +35,18 @@ class ApiEvaluateTest(BaseTestCase):
         mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
         mock_stub_class.return_value = mock_stub_obj
         aobj = create_app_obj()
-        service_id = create_service_obj(aobj.application_id).service_id
+        sobj = create_service_obj(aobj.application_id)
+        model_id = sobj.model_id
         create_eval_obj(aobj.application_id, save=True)
         create_eval_obj(aobj.application_id, save=True)
         create_eval_obj(aobj.application_id, save=True)
         newest_eval_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
 
-        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{service_id}/evaluate')
+        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate')
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
                                          'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
         eobj_exists = db.session.query(EvaluationResult)\
-            .filter(EvaluationResult.service_id == service_id,
+            .filter(EvaluationResult.model_id == model_id,
                     EvaluationResult.evaluation_id == newest_eval_id).one_or_none() is not None
         self.assertEqual(eobj_exists, True)

--- a/app/test/test_api_service.py
+++ b/app/test/test_api_service.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch, Mock
 
 import drucker_pb2
-from .base import BaseTestCase, create_app_obj, create_service_obj
-from io import BytesIO
+from .base import BaseTestCase, create_app_obj, create_service_obj, create_eval_obj
+from models import EvaluationResult, db
 
 
 class ApiEvaluateTest(BaseTestCase):
@@ -15,10 +15,36 @@ class ApiEvaluateTest(BaseTestCase):
         mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
         mock_stub_class.return_value = mock_stub_obj
         aobj = create_app_obj()
-        sobj = create_service_obj(aobj.application_id)
-        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{sobj.service_id}/evaluate',
-                                    content_type='multipart/form-data',
-                                    data=dict(file=(BytesIO(b'my file contents'), "work_order.123")))
+        service_id = create_service_obj(aobj.application_id).service_id
+        evaluation_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
+
+        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{service_id}/evaluate',
+                                    data={'evaluation_id': evaluation_id})
         self.assertEqual(200, response.status_code)
         self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
                                          'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
+        eobj_exists = db.session.query(EvaluationResult)\
+            .filter(EvaluationResult.service_id == service_id,
+                    EvaluationResult.evaluation_id == evaluation_id).one_or_none() is not None
+        self.assertEqual(eobj_exists, True)
+
+    @patch('core.drucker_dashboard_client.drucker_pb2_grpc.DruckerDashboardStub')
+    def test_post_without_param(self, mock_stub_class):
+        mock_stub_obj = Mock()
+        mock_stub_obj.EvaluateModel.return_value = drucker_pb2.EvaluateModelResponse()
+        mock_stub_class.return_value = mock_stub_obj
+        aobj = create_app_obj()
+        service_id = create_service_obj(aobj.application_id).service_id
+        create_eval_obj(aobj.application_id, save=True)
+        create_eval_obj(aobj.application_id, save=True)
+        create_eval_obj(aobj.application_id, save=True)
+        newest_eval_id = create_eval_obj(aobj.application_id, save=True).evaluation_id
+
+        response = self.client.post(f'/api/applications/{aobj.application_id}/services/{service_id}/evaluate')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(response.json, {'accuracy': 0.0, 'fvalue': 0.0, 'num': 0,
+                                         'option': {}, 'precision': 0.0, 'recall': 0.0, 'status': True})
+        eobj_exists = db.session.query(EvaluationResult)\
+            .filter(EvaluationResult.service_id == service_id,
+                    EvaluationResult.evaluation_id == newest_eval_id).one_or_none() is not None
+        self.assertEqual(eobj_exists, True)

--- a/app/utils/hash_util.py
+++ b/app/utils/hash_util.py
@@ -1,0 +1,23 @@
+from typing import Union
+import hashlib
+
+from werkzeug.datastructures import FileStorage
+
+
+class HashUtil:
+    @staticmethod
+    def checksum(f: Union[str, bytes, FileStorage]) -> str:
+        chunk_size = 4096
+        if isinstance(f, bytes):
+            hash_md5 = hashlib.md5(f)
+        elif isinstance(f, str):
+            hash_md5 = hashlib.md5()
+            with open(f, "rb") as infile:
+                for chunk in iter(lambda: infile.read(chunk_size), b""):
+                    hash_md5.update(chunk)
+        else:
+            hash_md5 = hashlib.md5()
+            for chunk in iter(lambda: f.read(chunk_size), b''):
+                hash_md5.update(chunk)
+
+        return hash_md5.hexdigest()


### PR DESCRIPTION
## What is this PR for?

Not to upload the same evaluation data, separate evaluate and upload test data

## This PR includes

- update grpc commit to https://github.com/rekcurd/drucker-grpc-proto/pull/12 
- Add API for UploadEvaluationData (POST and DELETE)
- change models (`Evaluation` -> info for evaluation data,  `EvaluationResult` -> info for evalution result)
- fix Evaluate API based on grpc change.

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

python -m unittest test/test_api_application.py
