### PR TITLE
Add cascade deletion for application_user_roles

### DIFF
--- a/drucker_dashboard/apis/api_evaluation.py
+++ b/drucker_dashboard/apis/api_evaluation.py
@@ -84,8 +84,6 @@ class ApiEvaluation(Resource):
             return {"status": False, "message": "Not Found."}, 404
 
         eval_query.delete()
-        db.session.query(EvaluationResult)\
-            .filter(EvaluationResult.evaluation_id == evaluation_id).delete()
         db.session.commit()
         db.session.close()
 

--- a/drucker_dashboard/apis/api_kubernetes.py
+++ b/drucker_dashboard/apis/api_kubernetes.py
@@ -347,9 +347,11 @@ def update_dbs_kubernetes(kubernetes_id:int, applist:set=None, description:str=N
             Service.application_id == aobj.application_id).delete()
         db.session.flush()
     if refresh_all:
-        db.session.query(Application).filter(
+        aobjs = db.session.query(Application).filter(
             Application.confirm_date <= process_date,
-            Application.kubernetes_id == kubernetes_id).delete()
+            Application.kubernetes_id == kubernetes_id).all()
+        for obj in aobjs:
+            db.session.delete(obj)
         db.session.flush()
 
 
@@ -1060,7 +1062,7 @@ class ApiKubernetesId(Resource):
             application_id = res.application_id
             db.session.query(Model).filter(Model.application_id == application_id).delete()
             db.session.query(Service).filter(Service.application_id == application_id).delete()
-            db.session.query(Application).filter(Application.application_id == application_id).delete()
+            db.session.delete(res)
         db.session.query(Kubernetes).filter(Kubernetes.kubernetes_id == kubernetes_id).delete()
         response_body = {"status": True, "message": "Success."}
         db.session.commit()

--- a/drucker_dashboard/apis/api_kubernetes.py
+++ b/drucker_dashboard/apis/api_kubernetes.py
@@ -347,11 +347,9 @@ def update_dbs_kubernetes(kubernetes_id:int, applist:set=None, description:str=N
             Service.application_id == aobj.application_id).delete()
         db.session.flush()
     if refresh_all:
-        aobjs = db.session.query(Application).filter(
+        db.session.query(Application).filter(
             Application.confirm_date <= process_date,
-            Application.kubernetes_id == kubernetes_id).all()
-        for obj in aobjs:
-            db.session.delete(obj)
+            Application.kubernetes_id == kubernetes_id).delete()
         db.session.flush()
 
 

--- a/drucker_dashboard/models/application_user_role.py
+++ b/drucker_dashboard/models/application_user_role.py
@@ -4,8 +4,10 @@ from sqlalchemy import (
     Column, Integer,
     Enum,
     ForeignKey,
+    UniqueConstraint
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref
 
 
 class Role(enum.Enum):
@@ -20,12 +22,15 @@ class ApplicationUserRole(db.Model):
     """
     __tablename__ = 'application_user_roles'
     __table_args__ = (
+        UniqueConstraint('application_id', 'user_id'),
         {'mysql_engine': 'InnoDB'}
     )
 
-    application_id = Column(Integer, ForeignKey('applications.application_id'), primary_key=True)
-    user_id = Column(Integer, ForeignKey('users.user_id'), primary_key=True)
+    application_id = Column(Integer, ForeignKey('applications.application_id', ondelete="CASCADE"), primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.user_id', ondelete="CASCADE"), primary_key=True)
     role = Column(Enum(Role), nullable=False, default=Role.viewer)
 
-    application = relationship('Application', lazy='joined', innerjoin=True)
-    user = relationship('User')
+    application = relationship('Application', lazy='joined', innerjoin=True,
+                               backref=backref("application_user_roles", cascade="all, delete-orphan"))
+    user = relationship('User',
+                        backref=backref("application_user_roles", cascade="all, delete-orphan"))

--- a/drucker_dashboard/models/application_user_role.py
+++ b/drucker_dashboard/models/application_user_role.py
@@ -31,6 +31,8 @@ class ApplicationUserRole(db.Model):
     role = Column(Enum(Role), nullable=False, default=Role.viewer)
 
     application = relationship('Application', lazy='joined', innerjoin=True,
-                               backref=backref("application_user_roles", cascade="all, delete-orphan"))
+                               backref=backref("application_user_roles",
+                                               cascade="all, delete-orphan", passive_deletes=True))
     user = relationship('User',
-                        backref=backref("application_user_roles", cascade="all, delete-orphan"))
+                        backref=backref("application_user_roles",
+                                        cascade="all, delete-orphan", passive_deletes=True))

--- a/drucker_dashboard/models/evaluation.py
+++ b/drucker_dashboard/models/evaluation.py
@@ -2,9 +2,11 @@ import datetime
 from .dao import db
 from sqlalchemy import (
     Column, Integer, DateTime,
-    String, UniqueConstraint
+    String, UniqueConstraint,
+    ForeignKey
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref
 
 
 class Evaluation(db.Model):
@@ -20,10 +22,13 @@ class Evaluation(db.Model):
 
     evaluation_id = Column(Integer, primary_key=True, autoincrement=True)
     checksum = Column(String(128), nullable=False)
-    application_id = Column(Integer, nullable=False)
+    application_id = Column(Integer, ForeignKey('applications.application_id', ondelete="CASCADE"), nullable=False)
     data_path = Column(String(512), nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
-    evaluation_result = relationship('EvaluationResult', backref='evaluations', lazy='select', innerjoin=True)
+
+    application = relationship(
+        'Application', innerjoin=True,
+        backref=backref("evaluations", cascade="all, delete-orphan", passive_deletes=True))
 
     @property
     def serialize(self):

--- a/drucker_dashboard/models/evaluation_result.py
+++ b/drucker_dashboard/models/evaluation_result.py
@@ -5,6 +5,8 @@ from sqlalchemy import (
     Column, Integer, DateTime, Text,
     UniqueConstraint, ForeignKey, String
 )
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref
 
 
 class EvaluationResult(db.Model):
@@ -20,9 +22,13 @@ class EvaluationResult(db.Model):
     evaluation_result_id = Column(Integer, primary_key=True, autoincrement=True)
     model_id = Column(Integer, nullable=False)
     data_path = Column(String(512), nullable=False)
-    evaluation_id = Column(Integer, ForeignKey('evaluations.evaluation_id'), nullable=False)
+    evaluation_id = Column(Integer, ForeignKey('evaluations.evaluation_id', ondelete="CASCADE"), nullable=False)
     _result = Column(Text, nullable=False)
     register_date = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+
+    evaluations = relationship(
+        'Evaluation', lazy='select', innerjoin=True,
+        backref=backref("evaluation_results", cascade="all, delete-orphan", passive_deletes=True))
 
     @property
     def result(self):

--- a/drucker_dashboard/utils/__init__.py
+++ b/drucker_dashboard/utils/__init__.py
@@ -30,6 +30,13 @@ class DruckerDashboardConfig:
         if self._DB_MODE == "sqlite":
             db_name = "db.test.sqlite3" if self.TEST_MODE else "db.sqlite3"
             self.DB_URL = f'sqlite:///{db_name}'
+            from sqlalchemy.engine import Engine
+            from sqlalchemy import event
+            @event.listens_for(Engine, "connect")
+            def set_sqlite_pragma(dbapi_connection, connection_record):
+                cursor = dbapi_connection.cursor()
+                cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.close()
         elif self._DB_MODE == "mysql":
             host = self._DB_MYSQL_HOST
             port = self._DB_MYSQL_PORT


### PR DESCRIPTION
## What is this PR for?

Because of the `ForeignKey`, we cannot delete `Application` model when we use an authentication.

## This PR includes

- Add `backref` to delete orphan
- Change the way of deletion since `query().delete()` doesn't support cascade deletion (See [link](https://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.delete))

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

```
python -m unittest drucker_dashboard/test/test_access_control.py
```