### PR TITLE
Set default role to `Role.viewer`

### DIFF
--- a/drucker_dashboard/apis/api_admin.py
+++ b/drucker_dashboard/apis/api_admin.py
@@ -38,7 +38,7 @@ def check_owner_role(fn):
         user_id = get_jwt_identity()
         application_id = kwargs.get('application_id')
         role = fetch_role(application_id, user_id)
-        if role is not None and role == Role.owner:
+        if role == Role.owner:
             return fn(*args, **kwargs)
         else:
             raise ApplicationUserRoleException


### PR DESCRIPTION
## What is this PR for?

We cannot recognize ML applications once we set role to someone to a certain application.
Viewer right should be assigned to everyone. So I set default role to `Role.viewer`.

## This PR includes

- Set default role to `Role.viewer`

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

```
python -m unittest drucker_dashboard/test/test_access_control.py
```