### PR TITLE
[Hotfix] Request only when model switched

### DIFF
--- a/frontend/src/components/App/Deploy/DeployStatusForm.tsx
+++ b/frontend/src/components/App/Deploy/DeployStatusForm.tsx
@@ -190,6 +190,7 @@ interface StateProps {
   switchModelsStatus: APIRequest<boolean[]>
   initialValues: {
     status
+    switch
     delete
   }
 }
@@ -205,6 +206,7 @@ const mapStateToProps = (state: any, extraProps: DeployStatusFormCustomProps) =>
     ...state.form,
     initialValues: {
       status: extraProps.deployStatus,
+      switch: extraProps.deployStatus,
       delete: {
         services: initialDeleteStatus
       }

--- a/frontend/src/components/App/Deploy/DeployStatusTable.tsx
+++ b/frontend/src/components/App/Deploy/DeployStatusTable.tsx
@@ -183,7 +183,7 @@ class DeployStatusTable extends React.Component<DeployStatusProps, {tooltipOpen}
       return (
         <Field
           component={CustomRadioButton}
-          name={`status.${serviceId}`}
+          name={`switch.${serviceId}`}
           serviceId={serviceId}
           modelId={model.id}
         />

--- a/frontend/src/components/App/Deploy/index.tsx
+++ b/frontend/src/components/App/Deploy/index.tsx
@@ -360,7 +360,14 @@ class Deploy extends React.Component<DeployStatusProps, DeployStatusState> {
     const { applicationId } = this.props.match.params
 
     const apiParams: SwitchModelParam[] =
-      Object.entries(params.status)
+      Object.entries(params.switch)
+        .filter(
+          ([key, value]) => {
+            if (params.status[key] === value) {
+              return false
+            }
+            return true
+          })
         .map(
           ([key, value]): SwitchModelParam => (
             {


### PR DESCRIPTION
## What is this PR for?

Currently frontend makes put requests to all services when the user switches at least one service. For this, all Kubernetes deployments are rolling updated. This PR will fix this issue.

## This PR includes

- Check the current modelId and filter it.

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

Try `Switch models`
