### PR TITLE
[Bug fix] Fix kube config filepath

### DIFF
--- a/drucker_dashboard/apis/api_service.py
+++ b/drucker_dashboard/apis/api_service.py
@@ -3,7 +3,7 @@ import datetime
 from flask_restplus import Namespace, fields, Resource, reqparse
 
 from . import DatetimeToTimestamp
-from .api_kubernetes import update_dbs_kubernetes, switch_drucker_service_model_assignment
+from .api_kubernetes import get_kube_config_path, update_dbs_kubernetes, switch_drucker_service_model_assignment
 from drucker_dashboard.models import db, Kubernetes, Application, Service
 
 
@@ -148,7 +148,7 @@ class ApiApplicationIdServiceId(Resource):
                 Kubernetes.kubernetes_id == kubernetes_id).one_or_none()
             if kobj is None:
                 raise Exception("No such kubernetes_id.")
-            config_path = kobj.config_path
+            config_path = get_kube_config_path(kobj.config_path)
             from kubernetes import client, config
             config.load_kube_config(config_path)
 

--- a/drucker_dashboard/apis/api_service.py
+++ b/drucker_dashboard/apis/api_service.py
@@ -3,7 +3,7 @@ import datetime
 from flask_restplus import Namespace, fields, Resource, reqparse
 
 from . import DatetimeToTimestamp
-from .api_kubernetes import get_kube_config_path, update_dbs_kubernetes, switch_drucker_service_model_assignment
+from .api_kubernetes import get_full_config_path, update_dbs_kubernetes, switch_drucker_service_model_assignment
 from drucker_dashboard.models import db, Kubernetes, Application, Service
 
 
@@ -148,9 +148,9 @@ class ApiApplicationIdServiceId(Resource):
                 Kubernetes.kubernetes_id == kubernetes_id).one_or_none()
             if kobj is None:
                 raise Exception("No such kubernetes_id.")
-            config_path = get_kube_config_path(kobj.config_path)
+            full_config_path = get_full_config_path(kobj.config_path)
             from kubernetes import client, config
-            config.load_kube_config(config_path)
+            config.load_kube_config(full_config_path)
 
             apps_v1 = client.AppsV1Api()
             v1_deployment = apps_v1.delete_namespaced_deployment(

--- a/e2e_test/base.py
+++ b/e2e_test/base.py
@@ -27,7 +27,7 @@ from drucker_dashboard.server import create_app
 from drucker_dashboard.models import db, Kubernetes, Application, Service, Model
 from drucker_dashboard.logger import JsonSystemLogger
 from drucker_dashboard.drucker_dashboard_client import DruckerDashboardClient
-from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
+from drucker_dashboard.apis.api_kubernetes import get_full_config_path
 
 
 def get_minikube_ip(profile):
@@ -160,7 +160,7 @@ class BaseTestCase(TestCase):
 
 def start_worker(config_path, namespace='development'):
     # Load configuration
-    k8s_config.load_kube_config(get_kube_config_path(config_path))
+    k8s_config.load_kube_config(get_full_config_path(config_path))
 
     # Deployment and Service
     try:
@@ -195,7 +195,7 @@ def start_worker(config_path, namespace='development'):
 
 def stop_worker(config_path, namespaces=('development', 'beta')):
     # Load configuration
-    k8s_config.load_kube_config(get_kube_config_path(config_path))
+    k8s_config.load_kube_config(get_full_config_path(config_path))
     body = k8s_client.V1DeleteOptions()
     core_v1 = k8s_client.CoreV1Api()
     app_v1 = k8s_client.AppsV1Api()
@@ -219,8 +219,8 @@ def stop_worker(config_path, namespaces=('development', 'beta')):
 def create_kube_obj(first=True, save=False):
     kube_setting = kube_setting1 if first else kube_setting2
     config_filename = uuid.uuid4().hex
-    config_path = get_kube_config_path(config_filename)
-    shutil.copyfile(kube_setting.config_path, config_path)
+    full_config_path = get_full_config_path(config_filename)
+    shutil.copyfile(kube_setting.config_path, full_config_path)
     kobj = Kubernetes(description=kube_setting.description,
                       config_path=config_filename,
                       dns_name=kube_setting.dns_name,

--- a/e2e_test/test_application.py
+++ b/e2e_test/test_application.py
@@ -7,7 +7,7 @@ from e2e_test.base import create_kube_obj
 from e2e_test.base import WorkerConfiguration
 from e2e_test.base import kube_setting1
 from drucker_dashboard.models import db, Application
-from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
+from drucker_dashboard.apis.api_kubernetes import get_full_config_path
 
 
 class TestApiEvaluate(BaseTestCase):
@@ -21,7 +21,7 @@ class TestApiWorker(BaseTestCase):
 
     def test_post(self):
         kobj = create_kube_obj()
-        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
+        k8s_config.load_kube_config(get_full_config_path(kobj.config_path))
         core_v1 = k8s_client.CoreV1Api()
         k8s_service = core_v1.read_namespaced_service(
             name=WorkerConfiguration.service['metadata']['name'],

--- a/e2e_test/test_application.py
+++ b/e2e_test/test_application.py
@@ -7,6 +7,8 @@ from e2e_test.base import create_kube_obj
 from e2e_test.base import WorkerConfiguration
 from e2e_test.base import kube_setting1
 from drucker_dashboard.models import db, Application
+from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
+
 
 class TestApiEvaluate(BaseTestCase):
 
@@ -19,7 +21,7 @@ class TestApiWorker(BaseTestCase):
 
     def test_post(self):
         kobj = create_kube_obj()
-        k8s_config.load_kube_config(kobj.config_path)
+        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
         core_v1 = k8s_client.CoreV1Api()
         k8s_service = core_v1.read_namespaced_service(
             name=WorkerConfiguration.service['metadata']['name'],

--- a/e2e_test/test_kubernetes.py
+++ b/e2e_test/test_kubernetes.py
@@ -4,7 +4,7 @@ from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 
 from drucker_dashboard.models import db, Kubernetes, Application, Service, Model
-from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
+from drucker_dashboard.apis.api_kubernetes import get_full_config_path
 
 from e2e_test.base import BaseTestCase
 from e2e_test.base import kube_setting2, create_kube_obj, create_app_obj, create_service_obj, create_model_obj
@@ -106,10 +106,10 @@ class TestApiKubernetesId(BaseTestCase):
         kobj = create_kube_obj(first=False, save=True)
         kubernetes_id = kobj.kubernetes_id
         update_entry = uuid.uuid4().hex
-        config_path = get_kube_config_path(kobj.config_path)
+        full_config_path = get_full_config_path(kobj.config_path)
         # Update some attributes via the PATCH method
         self.client.patch(f'/api/kubernetes/{kubernetes_id}',
-                          data={'file': (open(config_path, 'rb'), config_path),
+                          data={'file': (open(full_config_path, 'rb'), full_config_path),
                                 'dns_name': update_entry,
                                 'display_name': update_entry,
                                 'description': update_entry,
@@ -174,7 +174,7 @@ class TestApiKubernetesIdApplication(BaseTestCase):
     def test_post(self):
         # Create a kubernetes and retrieve its spec
         kobj = create_kube_obj()
-        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
+        k8s_config.load_kube_config(get_full_config_path(kobj.config_path))
 
         args = get_default_args()
         args['kubernetes_id'] = kobj.kubernetes_id
@@ -232,7 +232,7 @@ class TestApiKubernetesIdApplicationIdServices(BaseTestCase):
         args = get_default_args()
         del args['app_name']
         # Use client to check the deployment is created
-        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
+        k8s_config.load_kube_config(get_full_config_path(kobj.config_path))
         self.client.post(
             f'/api/kubernetes/{kobj.kubernetes_id}/applications/{aobj.application_id}/services',
             data=args)
@@ -264,7 +264,7 @@ class TestApiKubernetesIdApplicationIdServiceId(BaseTestCase):
         del args['app_name']
         del args['service_level']
         args['replicas_default'] = updated_replicas_default = 3
-        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
+        k8s_config.load_kube_config(get_full_config_path(kobj.config_path))
         self.client.patch(
             f'/api/kubernetes/{kobj.kubernetes_id}/applications/{aobj.application_id}/services/{sobj.service_id}',
             data=args)

--- a/e2e_test/test_kubernetes.py
+++ b/e2e_test/test_kubernetes.py
@@ -4,6 +4,7 @@ from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 
 from drucker_dashboard.models import db, Kubernetes, Application, Service, Model
+from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
 
 from e2e_test.base import BaseTestCase
 from e2e_test.base import kube_setting2, create_kube_obj, create_app_obj, create_service_obj, create_model_obj
@@ -105,9 +106,10 @@ class TestApiKubernetesId(BaseTestCase):
         kobj = create_kube_obj(first=False, save=True)
         kubernetes_id = kobj.kubernetes_id
         update_entry = uuid.uuid4().hex
+        config_path = get_kube_config_path(kobj.config_path)
         # Update some attributes via the PATCH method
         self.client.patch(f'/api/kubernetes/{kubernetes_id}',
-                          data={'file': (open(kobj.config_path, 'rb'), kobj.config_path),
+                          data={'file': (open(config_path, 'rb'), config_path),
                                 'dns_name': update_entry,
                                 'display_name': update_entry,
                                 'description': update_entry,
@@ -172,7 +174,7 @@ class TestApiKubernetesIdApplication(BaseTestCase):
     def test_post(self):
         # Create a kubernetes and retrieve its spec
         kobj = create_kube_obj()
-        k8s_config.load_kube_config(kobj.config_path)
+        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
 
         args = get_default_args()
         args['kubernetes_id'] = kobj.kubernetes_id
@@ -230,7 +232,7 @@ class TestApiKubernetesIdApplicationIdServices(BaseTestCase):
         args = get_default_args()
         del args['app_name']
         # Use client to check the deployment is created
-        k8s_config.load_kube_config(kobj.config_path)
+        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
         self.client.post(
             f'/api/kubernetes/{kobj.kubernetes_id}/applications/{aobj.application_id}/services',
             data=args)
@@ -262,7 +264,7 @@ class TestApiKubernetesIdApplicationIdServiceId(BaseTestCase):
         del args['app_name']
         del args['service_level']
         args['replicas_default'] = updated_replicas_default = 3
-        k8s_config.load_kube_config(kobj.config_path)
+        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
         self.client.patch(
             f'/api/kubernetes/{kobj.kubernetes_id}/applications/{aobj.application_id}/services/{sobj.service_id}',
             data=args)

--- a/e2e_test/test_service.py
+++ b/e2e_test/test_service.py
@@ -12,7 +12,7 @@ from drucker_dashboard.drucker_dashboard_client import DruckerDashboardClient
 from drucker_client import DruckerWorkerClient
 from drucker_dashboard.models import db, Service
 from drucker_dashboard.logger import JsonSystemLogger
-from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
+from drucker_dashboard.apis.api_kubernetes import get_full_config_path
 
 from e2e_test.base import BaseTestCase
 from e2e_test.base import WorkerConfiguration
@@ -108,7 +108,7 @@ class TestApiApplicationIdServiceId(BaseTestCase):
         namespace = sobj.service_level
 
         # Confirm each components exist -> no exception raises
-        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
+        k8s_config.load_kube_config(get_full_config_path(kobj.config_path))
         apps_v1 = k8s_client.AppsV1Api()
         core_v1 = k8s_client.CoreV1Api()
         extensions_v1beta1 = k8s_client.ExtensionsV1beta1Api()

--- a/e2e_test/test_service.py
+++ b/e2e_test/test_service.py
@@ -12,6 +12,7 @@ from drucker_dashboard.drucker_dashboard_client import DruckerDashboardClient
 from drucker_client import DruckerWorkerClient
 from drucker_dashboard.models import db, Service
 from drucker_dashboard.logger import JsonSystemLogger
+from drucker_dashboard.apis.api_kubernetes import get_kube_config_path
 
 from e2e_test.base import BaseTestCase
 from e2e_test.base import WorkerConfiguration
@@ -107,7 +108,7 @@ class TestApiApplicationIdServiceId(BaseTestCase):
         namespace = sobj.service_level
 
         # Confirm each components exist -> no exception raises
-        k8s_config.load_kube_config(kobj.config_path)
+        k8s_config.load_kube_config(get_kube_config_path(kobj.config_path))
         apps_v1 = k8s_client.AppsV1Api()
         core_v1 = k8s_client.CoreV1Api()
         extensions_v1beta1 = k8s_client.ExtensionsV1beta1Api()


### PR DESCRIPTION
## What is this PR for?

Cannot work kube.datadir if we change the value after registering kubernetes service. This is because DB entry of kubernetes.config_file is registered using kube.datadir value at the time.

***Important***
After merging this PR, we need to update DB entry by hand.

## This PR includes

- Change registration procedure.
- Change loading procedure.
- Fix tests

## What type of PR is it?

Bugfix

## What is the issue?

https://github.com/rekcurd/drucker-dashboard/issues/67

## How should this be tested?

```
python -m unittest
```